### PR TITLE
Dont use regex and fix definitionId

### DIFF
--- a/recordm/customUI/js/cob/_find_definition.js
+++ b/recordm/customUI/js/cob/_find_definition.js
@@ -1,51 +1,78 @@
 cob.custom.customize.push(async function(core, utils, ui) {
 
-    const definitionsRegex = /\$definitions/
-    const definitionIdRegex = /\$auto\.definitions\.id/
+    const keyword_defId = '$auto_definitionId'
+    const keyword_defName = '$definitions'
 
-    core.customizeAllInstances(async (instance, presenter) => {
-        const definitions = await loadDefinitions()
-        const options = definitions.map(def => `<option value="${def.name}" data-id="${def.id}">${def.name}</option>`).join("")
-        
-        presenter.findFieldPs(fp => definitionsRegex.test(fp.field.fieldDefinition.description))
-            .forEach(fp => {
-                const $fieldTable = fp.content().find("> table.instance\\.service\\.field")
-                const $input = $fieldTable.find(".field-value")
+    const getExtension = (fp, extension) => fp.field.fieldDefinition.configuration.extensions[extension]
 
-                if ($fieldTable.find(".js-select-definition").length > 0) {
-                    return
-                }
+    core.customizeAllInstances( function(instance, presenter) {
 
-                $input.css('display', 'none')
-                $input.after(`<select class="js-select-definition"><option></option>${options}</select>`)
+        loadDefinitions().then(definitions => {
 
-                const parentContent = fp.content()
-                
-                const allDefinitionIdFields = presenter.findFieldPs(childFp => 
-                    definitionIdRegex.test(childFp.field.fieldDefinition.description)
-                )
+            const options = definitions.map(def => `<option value="${def.name}" data-id="${def.id}">${def.name}</option>`).join("")
+            const fieldsToInject_id = presenter.findFieldPs( fp => getExtension(fp, keyword_defId))
 
-                const childFieldP = allDefinitionIdFields.find(childFp => {
-                    const childContentId = childFp.content().attr('id')
-                    return parentContent.find(`#${childContentId}`).length > 0
-                })
+            if(fieldsToInject_id.length > 0){
 
-                const $select = $fieldTable.find(".js-select-definition")
-                
-                $select.val(fp.getValue())
+                //for each field with $auto_definitionId keyword
+                fieldsToInject_id.forEach( async fieldToInject => {
 
-                $select.on('change', function() {
-                    const selectedName = this.value
-                    const selectedId = $(this).find(':selected').data('id')
-                    
-                    $input.val(selectedName).trigger('change')
-                    
-                    if (childFieldP) {
-                        const $childFieldInput = childFieldP.content().find("> table.instance\\.service\\.field .field-value")
-                        $childFieldInput.val(selectedId).trigger('change')
+                    fieldToInject.disable() //prevent user from changing it manually
+
+                    //get the argument of the keyword - field with the name of the definition
+                    const extension = getExtension(fieldToInject, keyword_defId)
+                    const field_name = extension && extension.args ? extension.args[0] : ""
+
+                    if(field_name){
+
+                        //wait for the select to be in the DOM (it is created in the $definitions keyword)
+                        waitForElement(`.js-select-definition[data-field-name="${field_name}"]`, (select) => {
+
+                            const initialOption = select.selectedOptions[0]
+                            const initialId = initialOption?.dataset.id
+                            fieldToInject.setValue(initialId)
+                            
+                            select.addEventListener("change", (e) => {
+                                const id = e.target.selectedOptions[0]?.dataset.id
+                                fieldToInject.setValue(id)
+                            })
+
+                        })
                     }
                 })
-            })
+            }
+
+
+            const fieldsToInject_name = presenter.findFieldPs( fp => getExtension(fp, keyword_defName))
+
+            if(fieldsToInject_name.length > 0){
+
+                //for each field with $definitions keyword
+                fieldsToInject_name.forEach( async fieldToInject_name => {
+
+                    const $fieldTable = fieldToInject_name.content().find("> table.instance\\.service\\.field")
+                    const $input = $fieldTable.find(".field-value")
+
+                    //if select doesn't exist yet, create it
+                    if ($fieldTable.find(`.js-select-definition[data-field-name="${fieldToInject_name.field.fieldDefinition.name}"]`).length == 0) {
+
+                        $input.css('display', 'none')
+                        $input.after(`<select class="js-select-definition" data-field-name="${fieldToInject_name.field.fieldDefinition.name}"><option></option>${options}</select>`)
+
+                        const $select = $fieldTable.find(".js-select-definition")
+
+                        $select.val(fieldToInject_name.getValue())
+
+                        $select.on('change', function() {
+                            const selectedName = this.value
+                            const selectedId = $(this).find(':selected').data('id')
+                            
+                            $input.val(selectedName).trigger('change')
+                        })
+                    }
+                })
+            }
+        })
     })
 
     async function loadDefinitions() {
@@ -59,6 +86,24 @@ cob.custom.customize.push(async function(core, utils, ui) {
                 ignoreErrors: true,
                 complete: (jqXHR, textStatus) => resolve(jqXHR.responseJSON)
             })
+        })
+    }
+
+    function waitForElement(selector, callback) {
+        const el = document.querySelector(selector)
+        if (el) return callback(el)
+
+        const observer = new MutationObserver(() => {
+            const el = document.querySelector(selector)
+            if (el) {
+                observer.disconnect()
+                callback(el)
+            }
+        })
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true
         })
     }
 })

--- a/recordm/customUI/js/cob/_find_definition.js
+++ b/recordm/customUI/js/cob/_find_definition.js
@@ -1,7 +1,7 @@
 cob.custom.customize.push(async function(core, utils, ui) {
 
-    const keyword_defId = '$auto_definitionId'
-    const keyword_defName = '$definitions'
+    const keywordDefinitionId = '$auto_definitionId'
+    const keywordDefinitions = '$definitions'
 
     const getExtension = (fp, extension) => fp.field.fieldDefinition.configuration.extensions[extension]
 
@@ -10,17 +10,17 @@ cob.custom.customize.push(async function(core, utils, ui) {
         loadDefinitions().then(definitions => {
 
             const options = definitions.map(def => `<option value="${def.name}" data-id="${def.id}">${def.name}</option>`).join("")
-            const fieldsToInject_id = presenter.findFieldPs( fp => getExtension(fp, keyword_defId))
+            const fieldsToInjectId = presenter.findFieldPs( fp => getExtension(fp, keywordDefinitionId))
 
-            if(fieldsToInject_id.length > 0){
+            if(fieldsToInjectId.length > 0){
 
                 //for each field with $auto_definitionId keyword
-                fieldsToInject_id.forEach( async fieldToInject => {
+                fieldsToInjectId.forEach( async fieldToInject => {
 
                     fieldToInject.disable() //prevent user from changing it manually
 
                     //get the argument of the keyword - field with the name of the definition
-                    const extension = getExtension(fieldToInject, keyword_defId)
+                    const extension = getExtension(fieldToInject, keywordDefinitionId)
                     const field_name = extension && extension.args ? extension.args[0] : ""
 
                     if(field_name){
@@ -43,29 +43,28 @@ cob.custom.customize.push(async function(core, utils, ui) {
             }
 
 
-            const fieldsToInject_name = presenter.findFieldPs( fp => getExtension(fp, keyword_defName))
+            const fieldsToInjectName = presenter.findFieldPs( fp => getExtension(fp, keywordDefinitions))
 
-            if(fieldsToInject_name.length > 0){
+            if(fieldsToInjectName.length > 0){
 
                 //for each field with $definitions keyword
-                fieldsToInject_name.forEach( async fieldToInject_name => {
+                fieldsToInjectName.forEach( async fieldToInjectName => {
 
-                    const $fieldTable = fieldToInject_name.content().find("> table.instance\\.service\\.field")
+                    const $fieldTable = fieldToInjectName.content().find("> table.instance\\.service\\.field")
                     const $input = $fieldTable.find(".field-value")
 
                     //if select doesn't exist yet, create it
-                    if ($fieldTable.find(`.js-select-definition[data-field-name="${fieldToInject_name.field.fieldDefinition.name}"]`).length == 0) {
+                    if ($fieldTable.find(`.js-select-definition[data-field-name="${fieldToInjectName.field.fieldDefinition.name}"]`).length == 0) {
 
                         $input.css('display', 'none')
-                        $input.after(`<select class="js-select-definition" data-field-name="${fieldToInject_name.field.fieldDefinition.name}"><option></option>${options}</select>`)
+                        $input.after(`<select class="js-select-definition" data-field-name="${fieldToInjectName.field.fieldDefinition.name}"><option></option>${options}</select>`)
 
                         const $select = $fieldTable.find(".js-select-definition")
 
-                        $select.val(fieldToInject_name.getValue())
+                        $select.val(fieldToInjectName.getValue())
 
                         $select.on('change', function() {
                             const selectedName = this.value
-                            const selectedId = $(this).find(':selected').data('id')
                             
                             $input.val(selectedName).trigger('change')
                         })


### PR DESCRIPTION
nao usar mais o regex, corrigir o $auto_definitionsId e em vez de ser referente ao campo pai, é referente ao campo que tem como argumento `$auto_definitionsId(argumento)`